### PR TITLE
Add Ethereum Localism site link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1104,6 +1104,17 @@
                       RefiDAO
                     </a>
                   </div>
+                  <div class="flex gap-2 items-center text-green hover:text-[var(--mid-green)] group">
+                    <svg class="group-hover:translate-x-1 transition-all duration-300" width="11" height="8"
+                      viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M0.5 3.5C0.223858 3.5 0 3.72386 0 4C0 4.27614 0.223858 4.5 0.5 4.5V3.5ZM10.3536 4.35355C10.5488 4.15829 10.5488 3.84171 10.3536 3.64645L7.17157 0.464466C6.97631 0.269204 6.65973 0.269204 6.46447 0.464466C6.2692 0.659728 6.2692 0.976311 6.46447 1.17157L9.29289 4L6.46447 6.82843C6.2692 7.02369 6.2692 7.34027 6.46447 7.53553C6.65973 7.7308 6.97631 7.7308 7.17157 7.53553L10.3536 4.35355ZM0.5 4.5H10V3.5H0.5V4.5Z"
+                        fill="currentColor" />
+                    </svg>
+                    <a href="https://www.ethereumlocalism.xyz">
+                      Ethereum Localism
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Adds "Ethereum Localism" to the Partnerships section - the network from which the Ethereum Localism book was produced. The Knowledge Garden site (ethereumlocalism.xyz) expands on the book by serving as an open repository documenting projects, tools, and community experiments exploring how Ethereum infrastructure can support local coordination, regenerative economies, and place-based organizing.

Thanks for considering! (I did see the note about reaching out via Discord, but I'm not on that platform)