### PR TITLE
docs: Linear-spawned issue contract for Codex in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,17 @@ Run installs and validation from the repo root.
 - `bun run ui:check` - source-only website CSS guardrails; no build, browser, or screenshots.
 - `bun run ui:verify <route>` - heavier website build + rendered browser proof at 375 / 1024 / 1440.
 
+## Linear-Spawned Issue Contract
+
+Linear (workspace `greenpill-dev-guild`; teams Product `PRD` / Research `RESR`) is the durable backlog — never open GitHub Issues for backlog work. Codex work is labeled `agent:codex` (distinct from `agent:claude` interactive and `agent:routine` cron writes). The Linear MCP is wired into the Codex environment for read/query and state transitions.
+
+When dispatched from a Linear issue, **that issue is your spec** — read it in full, plus this file and any `.plans/<feature>/` lane it references.
+
+- **Codex-ready gate.** Implement only if the issue gives all of: clear **acceptance criteria**, a named **surface / `package:*`** (`website` / `agent` / `admin` / `shared` / `workspace`), and **validation** (explicit, or the relevant commands above). If anything is missing, the scope is ambiguous, or it needs a cross-package or architecture decision — **stop and comment on the issue; do not guess.** A vague issue is a no-op.
+- **Executor, not orchestrator.** Implement only the scoped unit, in the smallest package boundary. Don't expand past the acceptance criteria or make sequencing decisions that belong to the human.
+- **Branch + PR.** Work on the integration branch named in the issue; the PR body must link it (`Closes PRD-NNN` / `Linear: PRD-NNN`). One issue per PR; never self-merge.
+- **Before the PR**, run the matching validation — `bun run typecheck`, the focused `bun run test:*` for the surface, `bun run agentic:check` for website/UI work, then `bun run build` — and produce evidence (passing output / rendered proof), not "should work." Honor the Privacy Boundary below.
+
 ## Architecture Notes
 
 The public website remains static. Keystatic is enabled only during local website dev for editorial and site-composition content; there is no deployed Keystatic server or public website database connection.


### PR DESCRIPTION
Adds a consistent **Linear-Spawned Issue Contract** to `AGENTS.md` so Codex operates reliably when delegated a Linear issue — part of a 3-repo rollout (green-goods, network, coop).

**Core (same across all three):**
- The **Linear issue is the spec** — read it + this file + any `.plans/<feature>` lane it references.
- **Codex-ready gate** — proceed only with acceptance criteria + named surface / `package:*` + validation; otherwise **stop and comment, don't guess**.
- **Executor, not orchestrator** — cross-lane sequencing lives in `.plans/status.json` + the human.
- **Branch + PR** — target the issue's integration branch; PR body links the issue (`Closes PRD-NNN`); never self-merge; contracts get extra review.
- Run the repo's validation gate (and produce evidence) before opening the PR.

Tailored per repo to its actual commands and existing structure — green-goods' Validation Ladder; coop's Planning-OS `*.codex.todo.md` lanes; network had no Linear/lane model before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
