### PR TITLE
fix(website): remove global z-index override for header

### DIFF
--- a/packages/website/src/layouts/GpLayout.astro
+++ b/packages/website/src/layouts/GpLayout.astro
@@ -134,7 +134,6 @@ const bodyClasses = [
     opacity: 0.075;
   }
 
-  body.gp-root .gp-site-header,
   body.gp-root .gp-main-target,
   body.gp-root .gp-site-footer {
     position: relative;


### PR DESCRIPTION
## Summary

Fix mobile menu accessibility issue caused by a z-index conflict.

## Details

I recently discovered your YouTube channel and really enjoyed the videos, which led me to check out the website.

While browsing the site on mobile, I noticed that the opened navigation menu could not be accessed. The root cause was a z-index override higher in the styling hierarchy, causing the menu to be rendered beneath another layer.

This change resolves the z-index conflict and restores proper mobile menu interaction.

Thanks for the great project and the YouTube content!

@Oba-One 