### PR TITLE
fix(agent,client): preserve map location integrity

### DIFF
--- a/packages/agent/src/map-locations.ts
+++ b/packages/agent/src/map-locations.ts
@@ -15,6 +15,13 @@ import { AgentDataError, PublicInputError } from './errors.js';
 type SqlLike = any;
 type FetchLike = typeof fetch;
 type UnknownRecord = Record<string, any>;
+export type MapLocationErrorStage = 'reverse_lookup' | 'reverse_confirmation_write';
+
+export interface MapLocationErrorEvent {
+  stage: MapLocationErrorStage;
+  errorName: string;
+  errorCode?: string;
+}
 
 export const MAP_LOCATION_SEARCH_ROUTE = '/map-locations/search';
 export const MAP_LOCATION_REVERSE_ROUTE = '/map-locations/reverse';
@@ -74,6 +81,16 @@ export interface MapLocationRepository {
 }
 
 const cleanString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+function mapLocationErrorEvent(stage: MapLocationErrorStage, error: unknown): MapLocationErrorEvent {
+  const errorRecord = error && typeof error === 'object' ? error as UnknownRecord : {};
+  const errorCode = cleanString(errorRecord.code);
+  return {
+    stage,
+    errorName: error instanceof Error ? error.name : 'UnknownError',
+    ...(errorCode ? { errorCode } : {}),
+  };
+}
 
 function normalizeOsmId(value: unknown): string {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
@@ -157,10 +174,13 @@ function normalizeCandidate(raw: unknown): NormalizedLocationCandidate | null {
 }
 
 function dedupeCandidates(candidates: NormalizedLocationCandidate[]): NormalizedLocationCandidate[] {
-  const seen = new Set<string>();
+  const seenProviderIds = new Set<string>();
+  const seenLabels = new Set<string>();
   return candidates.filter((candidate) => {
-    if (seen.has(candidate.providerId)) return false;
-    seen.add(candidate.providerId);
+    const labelKey = candidate.label.normalize('NFKC').replace(/\s+/g, ' ').toLocaleLowerCase('en-US');
+    if (seenProviderIds.has(candidate.providerId) || seenLabels.has(labelKey)) return false;
+    seenProviderIds.add(candidate.providerId);
+    seenLabels.add(labelKey);
     return true;
   }).slice(0, 5);
 }
@@ -515,11 +535,13 @@ export function createMapLocationRepository({
   fetchImpl = globalThis.fetch,
   env = process.env,
   now = () => new Date(),
+  reportError = (event) => console.warn('map_location_request_failed', event),
 }: {
   createSql?: (options?: { max?: number }) => SqlLike | null;
   fetchImpl?: FetchLike;
   env?: Record<string, string | undefined>;
   now?: () => Date;
+  reportError?: (event: MapLocationErrorEvent) => void;
 } = {}): MapLocationRepository {
   return {
     async findRepairCandidates(query) {
@@ -568,25 +590,39 @@ export function createMapLocationRepository({
       if (latitude === null || longitude === null) {
         throw new PublicInputError('invalid_coordinates', 'Choose a valid point on the map.');
       }
-      const candidates = await withSql(createSql, async (sql) => {
-        const timestamp = now();
-        await reservePublicLocationRequest(sql, requestMeta, timestamp);
-        return lookupCandidates(sql, {
-          key: geocoderCacheKey('reverse', latitude.toFixed(4), longitude.toFixed(4)),
-          kind: 'reverse',
-          now: timestamp,
-          load: () => nominatimRequest('reverse', {
-            lat: String(latitude),
-            lon: String(longitude),
-            zoom: '10',
-          }, { fetchImpl, env }),
+      let candidates: NormalizedLocationCandidate[];
+      try {
+        candidates = await withSql(createSql, async (sql) => {
+          const timestamp = now();
+          await reservePublicLocationRequest(sql, requestMeta, timestamp);
+          return lookupCandidates(sql, {
+            key: geocoderCacheKey('reverse', latitude.toFixed(4), longitude.toFixed(4)),
+            kind: 'reverse',
+            now: timestamp,
+            load: () => nominatimRequest('reverse', {
+              lat: String(latitude),
+              lon: String(longitude),
+              zoom: '10',
+            }, { fetchImpl, env }),
+          });
         });
-      });
+      } catch (error) {
+        if (!(error instanceof PublicInputError)) {
+          reportError(mapLocationErrorEvent('reverse_lookup', error));
+        }
+        throw error;
+      }
       const candidate = candidates[0];
       if (!candidate || distanceKm(latitude, longitude, candidate.lat, candidate.long) > MAP_LOCATION_REVERSE_MAX_DISTANCE_KM) {
         throw new PublicInputError('location_not_confirmed', 'That pin is too far from a confirmed place. Try another point.', 422);
       }
-      const confirmation = await withSql(createSql, (sql) => createConfirmation(sql, candidate, 'reverse'));
+      let confirmation: PublicMapLocation;
+      try {
+        confirmation = await withSql(createSql, (sql) => createConfirmation(sql, candidate, 'reverse'));
+      } catch (error) {
+        reportError(mapLocationErrorEvent('reverse_confirmation_write', error));
+        throw error;
+      }
       return assertPublicMapLocationPayload({ confirmation });
     },
 

--- a/packages/website/src/components/page-sections/HomeMap.astro
+++ b/packages/website/src/components/page-sections/HomeMap.astro
@@ -3732,6 +3732,24 @@ const statsA11y = `World map of ${chapterCount} Greenpill chapters. Approved ste
 
     addForm?.addEventListener('input', syncWalkthroughState);
     const safeJson = async (response: Response) => response.json().catch(() => ({}));
+    const clearLocationConfirmation = (): boolean => {
+      const hadConfirmation = Boolean(locationConfirmationInput?.value);
+      if (locationConfirmationInput) locationConfirmationInput.value = '';
+      if (placeInput) placeInput.value = '';
+      if (latInput) latInput.value = '';
+      if (longInput) longInput.value = '';
+      return hadConfirmation;
+    };
+    const clearLocationSelection = () => {
+      const hadConfirmation = clearLocationConfirmation();
+      if (locationPin) locationPin.hidden = true;
+      if (locationCoordinateLat) locationCoordinateLat.value = '';
+      if (locationCoordinateLong) locationCoordinateLong.value = '';
+      if (locationResults) locationResults.hidden = true;
+      if (locationResultsList) locationResultsList.replaceChildren();
+      syncWalkthroughState();
+      return hadConfirmation;
+    };
     const renderSearchResults = (results: ConfirmedLocation[]) => {
       if (!locationResults || !locationResultsList) return;
       locationResultsList.replaceChildren();
@@ -3754,10 +3772,13 @@ const statsA11y = `World map of ${chapterCount} Greenpill chapters. Approved ste
     const findLocation = async () => {
       const query = clean(locationQuery?.value);
       if (query.length < 3) {
+        invalidateLocationRequests();
+        clearLocationSelection();
         setLocationStatus('Enter at least three characters to find a place.', 'error');
         locationQuery?.focus();
         return;
       }
+      clearLocationSelection();
       const searchVersion = ++locationSearchVersion;
       locationRequestVersion += 1;
       if (locationSearchButton) locationSearchButton.disabled = true;
@@ -3800,6 +3821,14 @@ const statsA11y = `World map of ${chapterCount} Greenpill chapters. Approved ste
     };
 
     locationSearchButton?.addEventListener('click', () => void findLocation());
+    locationQuery?.addEventListener('input', () => {
+      const hadActiveSearch = Boolean(locationSearchButton?.disabled || !locationResults?.hidden);
+      invalidateLocationRequests();
+      const hadConfirmation = clearLocationSelection();
+      if (hadConfirmation || hadActiveSearch) {
+        setLocationStatus('Place changed. Find and choose a result to confirm your pin.');
+      }
+    });
     locationQuery?.addEventListener('keydown', (event) => {
       if (event.key !== 'Enter') return;
       event.preventDefault();
@@ -3819,14 +3848,6 @@ const statsA11y = `World map of ${chapterCount} Greenpill chapters. Approved ste
     };
 
     let locationDragging = false;
-    const clearLocationConfirmation = (): boolean => {
-      const hadConfirmation = Boolean(locationConfirmationInput?.value);
-      if (locationConfirmationInput) locationConfirmationInput.value = '';
-      if (placeInput) placeInput.value = '';
-      if (latInput) latInput.value = '';
-      if (longInput) longInput.value = '';
-      return hadConfirmation;
-    };
     const confirmDraggedLocation = async (point: { lat: number; long: number }) => {
       const requestVersion = ++locationRequestVersion;
       setLocationStatus('Confirming this pin…');

--- a/packages/website/src/pages/map/edit.astro
+++ b/packages/website/src/pages/map/edit.astro
@@ -66,6 +66,7 @@ const pageDescription = 'Private magic-link surface for requesting edits to publ
           let initialPublicFields = null;
           let locationConfirmationId = '';
           let locationSearchVersion = 0;
+          let currentLocationLabel = '';
 
           const hideAllStates = () => {
             loading.hidden = true;
@@ -150,7 +151,8 @@ const pageDescription = 'Private magic-link surface for requesting edits to publ
             nodeId = clean(node?.id);
             setTextField('display_name', clean(node?.display_name));
             locationConfirmationId = '';
-            locationCurrent.textContent = `Current location: ${clean(node?.place_name) || 'Unknown place'}`;
+            currentLocationLabel = clean(node?.place_name) || 'Unknown place';
+            locationCurrent.textContent = `Current location: ${currentLocationLabel}`;
             locationStatus.textContent = 'Find a new place only if you want to move this node.';
             locationStatus.removeAttribute('data-tone');
             locationResults.hidden = true;
@@ -285,6 +287,15 @@ const pageDescription = 'Private magic-link surface for requesting edits to publ
             else locationStatus.removeAttribute('data-tone');
           };
 
+          const clearLocationSelection = () => {
+            const hadConfirmation = Boolean(locationConfirmationId);
+            locationConfirmationId = '';
+            locationResults.hidden = true;
+            locationResultsList.replaceChildren();
+            locationCurrent.textContent = `Current location: ${currentLocationLabel || 'Unknown place'}`;
+            return hadConfirmation;
+          };
+
           const renderLocationResults = (results) => {
             locationResultsList.replaceChildren();
             results.forEach((result) => {
@@ -308,10 +319,14 @@ const pageDescription = 'Private magic-link surface for requesting edits to publ
           const findLocation = async () => {
             const query = clean(locationQuery.value);
             if (query.length < 3) {
+              locationSearchVersion += 1;
+              locationSearch.disabled = false;
+              clearLocationSelection();
               setLocationStatus('Enter at least three characters to find a place.', 'error');
               locationQuery.focus();
               return;
             }
+            clearLocationSelection();
             const searchVersion = ++locationSearchVersion;
             locationSearch.disabled = true;
             setLocationStatus('Finding matching places…');
@@ -342,6 +357,15 @@ const pageDescription = 'Private magic-link surface for requesting edits to publ
           };
 
           locationSearch.addEventListener('click', () => void findLocation());
+          locationQuery.addEventListener('input', () => {
+            const hadActiveSearch = Boolean(locationSearch.disabled || !locationResults.hidden);
+            locationSearchVersion += 1;
+            locationSearch.disabled = false;
+            const hadConfirmation = clearLocationSelection();
+            if (hadConfirmation || hadActiveSearch) {
+              setLocationStatus('Place changed. Find and choose a result to confirm the new location.');
+            }
+          });
           locationQuery.addEventListener('keydown', (event) => {
             if (event.key !== 'Enter') return;
             event.preventDefault();

--- a/scripts/agent-contract.test.ts
+++ b/scripts/agent-contract.test.ts
@@ -247,7 +247,7 @@ test('map-location route gives public request throttling a minute-long retry hin
   assert.equal(response.headers.get('retry-after'), '60');
 });
 
-function createFakeMapLocationSql({ cacheEntries = [] } = {}) {
+function createFakeMapLocationSql({ cacheEntries = [], confirmationError = null } = {}) {
   const cache = new Map(cacheEntries);
   const requestLimits = new Map();
   const statements = [];
@@ -286,6 +286,7 @@ function createFakeMapLocationSql({ cacheEntries = [] } = {}) {
       return [];
     }
     if (text.includes('insert into intake.map_location_confirmations')) {
+      if (confirmationError) throw confirmationError;
       confirmationCount += 1;
       return [{ confirmationId: `00000000-0000-4000-8000-${String(confirmationCount).padStart(12, '0')}` }];
     }
@@ -370,6 +371,13 @@ test('map-location search confirms numeric Nominatim ids and bypasses stale v1 e
         addresstype: 'city',
         osm_type: 'relation',
         osm_id: 9721587,
+      }, {
+        display_name: 'Nairobi, Kenya',
+        lat: '-1.3024317',
+        lon: '36.8172234',
+        addresstype: 'city',
+        osm_type: 'node',
+        osm_id: 249298629,
       }]);
     },
   });
@@ -377,6 +385,7 @@ test('map-location search confirms numeric Nominatim ids and bypasses stale v1 e
   const payload = await repository.search('Nairobi, Kenya');
 
   assert.equal(providerRequests.length, 1, 'the stale unversioned empty cache must not mask the provider fix');
+  assert.equal(payload.results.length, 1, 'identical public labels must not produce indistinguishable choices');
   assert.equal(payload.results[0].label, 'Nairobi, Kenya');
   assert.match(payload.results[0].confirmationId, /^[0-9a-f-]{36}$/i);
   const cacheRead = statements.find((statement) => statement.text.includes('from intake.map_location_geocode_cache'));
@@ -417,6 +426,84 @@ test('map-location reverse requests locality zoom and confirms a numeric-id Nair
   const confirmationWrite = statements.find((statement) => statement.text.includes('insert into intake.map_location_confirmations'));
   assert.ok(confirmationWrite);
   assert.equal(confirmationWrite.values.includes('relation:3854414'), true);
+});
+
+test('map-location reverse reports only safe confirmation-write diagnostics and preserves the error', async () => {
+  const databaseError = Object.assign(new Error('private database detail'), {
+    name: 'PostgresError',
+    code: '23514',
+    detail: 'private row detail',
+  });
+  const diagnosticEvents = [];
+  const { sql } = createFakeMapLocationSql({ confirmationError: databaseError });
+  const repository = createMapLocationRepository({
+    createSql: () => sql,
+    reportError: (event) => diagnosticEvents.push(event),
+    now: () => new Date('2026-07-12T12:00:00.000Z'),
+    fetchImpl: async () => Response.json({
+      display_name: 'Kilimani ward, Nairobi, Kenya',
+      lat: '-1.2920659',
+      lon: '36.7966194',
+      addresstype: 'neighbourhood',
+      osm_type: 'relation',
+      osm_id: 3854414,
+    }),
+  });
+
+  await assert.rejects(
+    repository.reverse(-1.286389, 36.817223),
+    (error) => error === databaseError
+  );
+  assert.deepEqual(diagnosticEvents, [{
+    stage: 'reverse_confirmation_write',
+    errorName: 'PostgresError',
+    errorCode: '23514',
+  }]);
+  assert.equal(JSON.stringify(diagnosticEvents).includes('private'), false);
+});
+
+test('map-location reverse reports only safe lookup diagnostics and preserves the error', async () => {
+  const databaseError = Object.assign(new Error('private database detail'), {
+    name: 'PostgresError',
+    code: '57P01',
+    detail: 'private connection detail',
+  });
+  const diagnosticEvents = [];
+  const repository = createMapLocationRepository({
+    createSql: () => { throw databaseError; },
+    reportError: (event) => diagnosticEvents.push(event),
+  });
+
+  await assert.rejects(
+    repository.reverse(-1.286389, 36.817223),
+    (error) => error === databaseError
+  );
+  assert.deepEqual(diagnosticEvents, [{
+    stage: 'reverse_lookup',
+    errorName: 'PostgresError',
+    errorCode: '57P01',
+  }]);
+  assert.equal(JSON.stringify(diagnosticEvents).includes('private'), false);
+});
+
+test('map-location reverse does not report expected public request limits as failures', async () => {
+  const diagnosticEvents = [];
+  const repository = createMapLocationRepository({
+    createSql: () => {
+      throw new PublicInputError(
+        'location_request_rate_limited',
+        'Too many location checks came from this network. Please try again in a minute.',
+        429
+      );
+    },
+    reportError: (event) => diagnosticEvents.push(event),
+  });
+
+  await assert.rejects(
+    repository.reverse(-1.286389, 36.817223),
+    (error) => error instanceof PublicInputError && error.status === 429
+  );
+  assert.deepEqual(diagnosticEvents, []);
 });
 
 test('map-location repository rejects malformed successful provider payloads without caching a false no-result', async () => {

--- a/scripts/map-edit-route.test.ts
+++ b/scripts/map-edit-route.test.ts
@@ -425,6 +425,55 @@ test('confirmed place search submits only a server confirmation id, never raw co
   assert.equal(Object.hasOwn(body, 'place_name'), false);
 });
 
+test('changing a confirmed place query clears the stale confirmation before submit', async () => {
+  const fetches = [];
+  const harness = createHarness({
+    fetchImpl: async (url, init) => {
+      fetches.push({ url, init });
+      if (url.endsWith('/map-nodes/edit-session')) {
+        return routeFetchResponse(200, { node: editableNode });
+      }
+      if (url.endsWith('/map-locations/search')) {
+        return routeFetchResponse(200, {
+          results: [{
+            confirmationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            label: 'Awka, Anambra, Nigeria',
+            lat: 6.2127,
+            long: 7.0717,
+            kind: 'settlement',
+            attribution: '© OpenStreetMap contributors',
+          }],
+        });
+      }
+      return routeFetchResponse(201, { updateRequest: { id: 'request-1', status: 'pending' } });
+    },
+  });
+
+  await runDomLoaded(harness);
+  const query = harness.elements.get('map-edit-location-query');
+  query.value = 'Awka, Nigeria';
+  await harness.elements.get('map-edit-location-search').listeners.get('click')();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  harness.elements.get('map-edit-location-results-list').children[0].children[0].listeners.get('click')();
+
+  query.value = 'London, United Kingdom';
+  query.listeners.get('input')();
+  assert.equal(
+    harness.elements.get('map-edit-location-current').textContent,
+    `Current location: ${editableNode.place_name}`
+  );
+  assert.equal(harness.elements.get('map-edit-location-results').hidden, true);
+  assert.match(harness.elements.get('map-edit-location-status').textContent, /Place changed/i);
+
+  harness.inputs.get('public_note').value = 'Updated public note.';
+  await harness.form.listeners.get('submit')({ preventDefault() {} });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(fetches.length, 3);
+  const body = JSON.parse(fetches[2].init.body);
+  assert.equal(Object.hasOwn(body, 'locationConfirmationId'), false);
+});
+
 test('production hostname uses the production agent endpoint', async () => {
   const fetches = [];
   const harness = createHarness({

--- a/scripts/map-node-contract.test.ts
+++ b/scripts/map-node-contract.test.ts
@@ -1493,6 +1493,9 @@ test('home map location picker searches, confirms, then reverse-confirms a dragg
   assert.match(component, /const invalidateLocationRequests/);
   assert.match(component, /locationRequestVersion \+= 1/);
   assert.match(component, /searchVersion !== locationSearchVersion/);
+  assert.match(component, /locationQuery\?\.addEventListener\('input',[\s\S]*?invalidateLocationRequests\(\)[\s\S]*?clearLocationSelection\(\)/);
+  assert.match(component, /const clearLocationConfirmation[\s\S]*?locationConfirmationInput\.value = ''/);
+  assert.match(component, /const clearLocationSelection[\s\S]*?clearLocationConfirmation\(\)[\s\S]*?locationPin\.hidden = true/);
   assert.match(component, /resetWalkthrough[\s\S]*?invalidateLocationRequests\(\)/);
   assert.match(component, /pointerdown[\s\S]*?invalidateLocationRequests\(\)/);
   assert.match(component, /pointercancel[\s\S]*?Pin adjustment canceled/);


### PR DESCRIPTION
## Summary
- Accept numeric Nominatim IDs, request locality-level reverse results, and bypass stale empty geocoder cache entries.
- Deduplicate indistinguishable public places and clear stale confirmation state when homepage or edit queries change.
- Add privacy-safe reverse diagnostics and focused regression coverage for search, reverse, cache, and website submission contracts.

## Validation
- [x] `bun run typecheck`
- [x] `bun run build:packages`
- [x] `bun run test:agent`
- [x] `bun run test:map-nodes`
- [x] `bun run test:map-edit`
- [x] `bun run test:chapter-impact`
- [x] `bun run test:content`
- [x] `bun run test:plans`
- [x] `bun run agentic:check`
- [x] `bun run build:website`
- [x] Fly release 47 health and readiness pass; Nairobi reverse confirmation returns 200.