### PR TITLE
fix(linear): rename the agent:* label family to ai:* in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Run installs and validation from the repo root.
 
 ## Linear-Spawned Issue Contract
 
-Linear (workspace `greenpill-dev-guild`; teams Product `PRD` / Research `RESR`) is the durable backlog — never open GitHub Issues for backlog work. Codex work is labeled `agent:codex` (distinct from `agent:claude` interactive and `agent:routine` cron writes). The Linear MCP is wired into the Codex environment for read/query and state transitions.
+Linear (workspace `greenpill-dev-guild`; teams Product `PRD` / Research `RESR`) is the durable backlog — never open GitHub Issues for backlog work. Codex work is labeled `ai:codex` (distinct from `ai:claude` interactive and `ai:routine` cron writes). The Linear MCP is wired into the Codex environment for read/query and state transitions.
 
 **Plan Hub Linear Mirror Policy**: scoped `.plans/ideas` and `.plans/backlog` hubs get one parent Linear issue for visibility. Do not create lane child issues, delegate agents, or treat scoped lane sketches as implementation specs until the human explicitly starts implementation or the hub moves to active execution. When implementation starts, create child issues only for the `.plans` lanes that are actionable at that time. If a scoped plan drifts before implementation, update the hub and parent issue first; do not rewrite a stale child tree.
 


### PR DESCRIPTION
Closes PRD-756.

Every routine spec and agent-facing doc told writers to apply `agent:routine` / `agent:codex` / `agent:claude`. **No `agent` label group exists in Linear.** The live group is `ai`, with exactly those three children. Because `save_issue` rejects the *entire* label array when any one entry fails to resolve, an agent following the docs literally got a hard write failure and filed nothing. That is how `health-watch` hit this while filing PRD-755.

Verified against live Linear before changing anything: the `ai` group holds `routine` (`90260e40…`), `codex` (`50724377…`), `claude` (`33e73a3a…`), and there is no `agent` group.

## Two traps this rename had to avoid

- **`package:agent` is a real, unrelated label** (the agent runtime package) and is untouched. This was not a find-and-replace of the word "agent"; the substitutions were scoped to the four label tokens.
- **`agent:copilot`** appeared in the operating model as an example and has **no `ai:` equivalent at all**. The live group is only routine/codex/claude, so it was dropped rather than translated.

## The second finding, also from PRD-756

The `group:child` notation these docs use throughout is **display shorthand, not accepted API input**. `save_issue` resolves labels by bare child name or ID, so `["protocol:green-goods", "activity:qa"]` fails where `["green-goods", "qa"]` succeeds. PRD-756's own label array reads `[routine, qa, docs, green-goods]`, which is the proof. This is now stated at the canonical definition and at both routine-facing indexes, since that is where writers actually look.

## One further correction found while reading

The guild routines README said to "optionally **add** `ai:claude` or `ai:codex`" on top of `ai:routine`. Linear enforces one child per grouped family, so that write would be rejected for exactly the same reason as the original bug. It now says they replace rather than accompany.

## Not in this PR

`green-goods/.plans/active/commitment-pooling/**` also carries `agent:*` references. Left alone deliberately: the audit reports and `status.json` event log are dated historical records that should not be rewritten, and the lane data is live input to `plan-hub.mjs linear-sync` for a feature another agent is actively working. It needs its own scoped pass, with the `plan-hub.test.mjs` fixtures moving in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)