### PR TITLE
feat(agent): add publish-health watchdog

### DIFF
--- a/.plans/active/directus-cms-advancement/eval.md
+++ b/.plans/active/directus-cms-advancement/eval.md
@@ -2,6 +2,25 @@
 
 ## Evidence log
 
+### 2026-08-11 PRD-808 publish-health draft
+
+- Added a static `/build-metadata.json` website artifact with only build time
+  and the public operational snapshot `generatedAt`; a 47-page Astro build
+  emitted the expected JSON with no Directus or intake payloads.
+- Added migration 028 with singleton content watermark/deployed build/Pages
+  workflow/check/active-alert/recovery state and deduplicated publish-health
+  events on the existing durable review-notification queue.
+- Added the opt-in content-operations check for the deployed artifact and latest
+  completed `github-pages.yml` run. URL and stale threshold are explicit agent
+  settings; production activation still requires Actions read on the existing
+  fine-grained token.
+- Fresh focused proof: package compilation passed; agent suites passed 82 tests;
+  content suite passed 23 tests; healthy, stale, build-failed, repeated, and
+  recovered transitions plus public safety and Resend delivery are covered.
+- No production migration, Fly deploy, secret/token change, or live alert test
+  was performed. The full root typecheck remains blocked by four unchanged
+  PRD-809 `directus-studio-setup.ts` errors already present on `main`.
+
 ### 2026-08-11 implementation pass
 
 - Local stack (fresh bootstrap): migrations 023-027 applied; dynamic-policy
@@ -30,6 +49,7 @@
 ## Acceptance Checks
 
 ### Phase 0
+
 - No repo doc claims stewards cannot publish their own scoped rows; role
   description, field notes, guide, and READMEs all describe the direct-edit
   model consistently.
@@ -39,6 +59,7 @@
   named proof surface.
 
 ### Phase 1
+
 - A steward edit to a published chapter is visible on greenpill.network in
   under 10 minutes without any human action (dispatch observed in the Pages
   workflow run list with event `repository_dispatch`).
@@ -64,6 +85,7 @@
   or decline the node, the outcome is verified, and the test node is archived.
 
 ### Phase 2
+
 - Creating a `chapter_editor_assignments` row in the Directus UI grants
   editing within one request cycle; deleting it revokes access (proved in
   extended steward smoke).
@@ -74,6 +96,7 @@
   steward at once (no per-user sync step).
 
 ### Phase 3
+
 - Chapters form renders grouped sections; links/proof use structured O2M
   editors, while direct chapter image alt/credit use first-class fields.
 - Existing `media.imageAlt`/`media.imageCredit` values survive migration and
@@ -90,6 +113,7 @@
   payloads or hidden technical fields.
 
 ### Phase 4
+
 - Either: accepted update requests apply to the live chapter row without
   retyping (SQL function tested), or: content versioning pilot documented
   with draft-promote flow and the request-table retirement plan.

--- a/.plans/active/directus-cms-advancement/handoffs/README.md
+++ b/.plans/active/directus-cms-advancement/handoffs/README.md
@@ -3,10 +3,12 @@
 ## 2026-08-11 implementation handoff (Claude -> Afo)
 
 Implementation state after the 2026-08-10/11 push: the main production slice
-shipped, but the platform and UI lanes remain active for the freshness
-watchdog, operator Insights dashboard, direct-edit chapter image metadata, and
-pt-BR/es label metadata. Production has migrations 023-027, the deployed agent
-with content-operations sweeps, and the v2 permission model applied.
+shipped, and the PRD-808 freshness watchdog is implemented and locally tested
+on its draft branch. The platform lane remains active for merge and separately
+authorized production activation; the UI lane remains active for the operator
+Insights dashboard, direct-edit chapter image metadata, and pt-BR/es label
+metadata. Production still has migrations 023-027, the deployed agent with
+content-operations sweeps, and the v2 permission model applied.
 
 ### Operator activations
 
@@ -41,9 +43,13 @@ with content-operations sweeps, and the v2 permission model applied.
 
 ### Remaining implementation sequence (tracked in plan.todo.md)
 
-1. PRD-808: static deployed build metadata, durable publish-health state,
-   GitHub Pages failure detection, and deduplicated Resend alerts/recoveries.
-   Activation requires Actions read on the fine-grained GitHub token.
+1. PRD-808 implementation is ready on branch
+   `afo/prd-808-cms-platform-lane-pipeline-automation-apply-function`: static
+   deployed build metadata, migration 028 durable publish-health state, GitHub
+   Pages failure detection, and deduplicated Resend alerts/recoveries. Release
+   order is merge -> apply migration 028 -> grant Actions read to the
+   fine-grained token -> set the explicit metadata URL/stale threshold and
+   enable flag -> deploy -> run the separately authorized live alert proof.
 2. PRD-809: first-class direct chapter alt/credit columns with backfill and
    projection compatibility, followed by the operator Insights dashboard and
    confirmed pt-BR/es Data Studio locale metadata.

--- a/.plans/active/directus-cms-advancement/plan.todo.md
+++ b/.plans/active/directus-cms-advancement/plan.todo.md
@@ -39,17 +39,19 @@ Full evidence for every item: `reports/cms-review-2026-08-10.md`.
       to `greenpill-dev-guild/network`; PAT stays in agent Fly secrets.
       Directus Flow variant explicitly declined to avoid future flow caps and
       keep secrets off the CMS.
-- [ ] Publish-failure + freshness alerting:
-  - [ ] Add a public-safe, static website build-metadata artifact containing
+- [x] Publish-failure + freshness alerting (implemented and tested on the
+      PRD-808 draft branch; production activation remains a separate operator
+      step):
+  - [x] Add a public-safe, static website build-metadata artifact containing
         the operational snapshot `generatedAt`; the agent must poll the
         deployed artifact rather than its live snapshot endpoint.
-  - [ ] Persist the latest content watermark, deployed build timestamp,
+  - [x] Persist the latest content watermark, deployed build timestamp,
         GitHub Pages workflow conclusion, check time, and alert state so
         stale/failing/recovered transitions are durable and deduplicated.
-  - [ ] Compare the deployed timestamp with `max(updated_at)` across the
+  - [x] Compare the deployed timestamp with `max(updated_at)` across the
         operational-content tables on the existing content-operations sweep;
         make the URL and stale threshold explicit agent env settings.
-  - [ ] Query the `github-pages.yml` workflow result and route stale/build
+  - [x] Query the `github-pages.yml` workflow result and route stale/build
         failure alerts through the existing durable Resend queue, including a
         recovery notification. The production fine-grained token must include
         Actions read in addition to Contents read/write before activation.
@@ -88,7 +90,7 @@ Full evidence for every item: `reports/cms-review-2026-08-10.md`.
 ### Phase 2 - Permissions v2 (kill the staleness class)
 
 - [x] Replace per-slug scoped policies with one static `Greenpill Assigned
-      Editor` policy using dynamic relational filters over the existing
+    Editor` policy using dynamic relational filters over the existing
       junction tables, e.g. chapters update:
       `{"editor_assignments":{"directus_user_id":{"_eq":"$CURRENT_USER"}}}`,
       initiatives via `{"chapter":{"editor_assignments":{...}}}` traversal.
@@ -173,10 +175,11 @@ Full evidence for every item: `reports/cms-review-2026-08-10.md`.
 
 ## Remaining implementation sequence
 
-1. **Platform health contract (PRD-808).** Add the build-metadata artifact,
-   persistent publish-health state, GitHub Pages result check, deduplicated
-   Resend alerts/recoveries, and focused agent/content tests. Do not activate
-   production polling until the fine-grained token has Actions read.
+1. **Platform health contract (PRD-808).** Implemented and locally tested on
+   the PRD-808 draft branch: build metadata, migration 028 state, Pages result
+   check, deduplicated Resend alerts/recoveries, and focused tests. Merge and
+   production activation remain separate; do not enable polling until migration
+   028 is applied and the fine-grained token has Actions read.
 2. **Steward/operator UX closure (PRD-809).** Add direct chapter image
    alt/credit columns and compatibility projection first; then implement the
    idempotent Insights dashboard against the persisted health state and add

--- a/.plans/active/directus-cms-advancement/spec.md
+++ b/.plans/active/directus-cms-advancement/spec.md
@@ -108,7 +108,12 @@ pinned version already ships.
 - **`content.people`**: defer - keep as published-read reference data; the
   dual source of truth stays documented debt.
 
-## Remaining implementation contract (Codex reconciliation, 2026-08-11)
+## Platform health implementation contract (PRD-808, 2026-08-11)
+
+Implemented and locally tested on the PRD-808 draft branch. Migration apply,
+token permission changes, agent configuration/deploy, and live alert proof are
+separate release actions; the platform lane remains in progress until those
+authorized steps and merge are complete.
 
 - **Freshness source**: publish a public-safe static build-metadata artifact
   from the website build. The agent must compare that deployed artifact with

--- a/.plans/active/directus-cms-advancement/status.json
+++ b/.plans/active/directus-cms-advancement/status.json
@@ -10,7 +10,7 @@
     "overall_status": "active",
     "priority": "p1",
     "created_at": "2026-08-10T22:49:27.561Z",
-    "updated_at": "2026-08-11T17:24:12.000Z"
+    "updated_at": "2026-08-11T18:20:20.000Z"
   },
   "links": {
     "brief": "brief.md",
@@ -25,25 +25,17 @@
   ],
   "taxonomy": {
     "initiative": "steward-experience",
-    "tracks": [
-      "admin-cms",
-      "content-pipeline",
-      "permissions"
-    ],
-    "work_types": [
-      "audit",
-      "implementation"
-    ],
+    "tracks": ["admin-cms", "content-pipeline", "permissions"],
+    "work_types": ["audit", "implementation"],
     "surfaces": [
       "packages/admin",
       "packages/agent",
       "packages/shared",
+      "packages/website",
       "scripts",
       "docs"
     ],
-    "depends_on_features": [
-      "content-private-node-scaffold"
-    ]
+    "depends_on_features": ["content-private-node-scaffold"]
   },
   "lanes": {
     "ui": {
@@ -67,19 +59,13 @@
     "qa_pass_1": {
       "owner": "claude",
       "status": "completed",
-      "depends_on": [
-        "ui",
-        "content",
-        "platform"
-      ],
+      "depends_on": ["ui", "content", "platform"],
       "handoff": "handoffs/README.md"
     },
     "qa_pass_2": {
       "owner": "codex",
       "status": "blocked",
-      "depends_on": [
-        "qa_pass_1"
-      ],
+      "depends_on": ["qa_pass_1"],
       "handoff": "handoffs/README.md"
     }
   },
@@ -125,6 +111,13 @@
       "lane": "system",
       "status": "in_progress",
       "note": "Reconciled the active plan with the child-issue audit: Codex owns the reopened platform and UI lanes for the freshness watchdog, operator dashboard, direct-edit image metadata, and locale labels; qa_pass_2 is blocked until those slices and the human magic-link decision are complete."
+    },
+    {
+      "timestamp": "2026-08-11T18:20:20.000Z",
+      "actor": "codex",
+      "lane": "platform",
+      "status": "in_progress",
+      "note": "Implemented and locally tested the PRD-808 publish-health watchdog on its draft branch: static public build metadata, migration 028 durable state, GitHub Pages checks, and deduplicated alert/recovery delivery. Merge and separately authorized production activation remain; PRD-809 and human QA stay blocked/out of scope."
     }
   ]
 }

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -62,3 +62,25 @@ from the Resend webhook details page before enabling the production endpoint, an
 set `RESEND_WEBHOOK_RECIPIENT_HASH_SECRET` so stored recipient hashes are keyed.
 The route verifies Svix signatures and stores only operational metadata, never
 message bodies, raw recipient addresses, or free-form provider diagnostics.
+
+## Website Publish Health
+
+The content-operations sweep can compare the deployed static website build with
+the latest operational-content update and completed GitHub Pages workflow. It is
+off unless all of these agent settings are supplied explicitly:
+
+- `CONTENT_PUBLISH_HEALTH_ENABLED=true`
+- `CONTENT_PUBLISH_HEALTH_METADATA_URL=https://greenpill.network/build-metadata.json`
+- `CONTENT_PUBLISH_HEALTH_STALE_THRESHOLD_MS=<positive milliseconds>`
+
+The check reuses `CONTENT_DISPATCH_GITHUB_REPO` and
+`CONTENT_DISPATCH_GITHUB_TOKEN`, and defaults the workflow filename to
+`github-pages.yml` and production branch to `main` unless
+`CONTENT_PUBLISH_HEALTH_WORKFLOW` or `CONTENT_PUBLISH_HEALTH_BRANCH` is set. The
+token must have Actions read in addition to the Contents access used for
+dispatch. Alerts and recoveries use `CONTENT_REVIEW_RECIPIENTS` and the existing
+durable Resend queue.
+
+Apply migration `028_content_publish_health.sql` before enabling this sweep.
+Enabling it, changing the production token, deploying the agent, and proving a
+live alert are separate operator actions, not part of the implementation PR.

--- a/packages/agent/migrations/028_content_publish_health.sql
+++ b/packages/agent/migrations/028_content_publish_health.sql
@@ -1,0 +1,94 @@
+-- Durable website publish-health state and alert delivery.
+--
+-- The public website exposes only static build timestamps. The agent compares
+-- those timestamps with the latest operational-content update and the latest
+-- completed GitHub Pages workflow, then records transitions here. Alerts reuse
+-- content.review_notifications so provider retries and delivery audit stay in
+-- the existing durable queue. No recipient addresses or private intake data are
+-- stored in either table.
+
+create table if not exists content.publish_health (
+  id text primary key default 'website',
+  content_watermark timestamptz,
+  deployed_build_at timestamptz,
+  deployed_snapshot_generated_at timestamptz,
+  latest_pages_run_id text not null default '',
+  latest_pages_run_url text not null default '',
+  latest_pages_conclusion text not null default '',
+  latest_pages_completed_at timestamptz,
+  stale_threshold_ms bigint,
+  checked_at timestamptz,
+  stale_alert_active boolean not null default false,
+  build_failed_alert_active boolean not null default false,
+  stale_recovered_at timestamptz,
+  build_failed_recovered_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint content_publish_health_singleton_check check (id = 'website'),
+  constraint content_publish_health_threshold_check check (
+    stale_threshold_ms is null or stale_threshold_ms > 0
+  )
+);
+
+insert into content.publish_health (id)
+values ('website')
+on conflict (id) do nothing;
+
+create or replace function content.touch_publish_health_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists content_publish_health_touch_updated_at
+  on content.publish_health;
+create trigger content_publish_health_touch_updated_at
+  before update on content.publish_health
+  for each row execute function content.touch_publish_health_updated_at();
+
+alter table content.review_notifications
+  add column if not exists event_key text not null default '',
+  add column if not exists publish_health_kind text not null default '',
+  add column if not exists publish_health_status text not null default '',
+  add column if not exists publish_health_details jsonb not null default '{}'::jsonb;
+
+alter table content.review_notifications
+  drop constraint if exists content_review_notification_kind_check;
+alter table content.review_notifications
+  add constraint content_review_notification_kind_check
+  check (kind in (
+    'update_request_pending',
+    'update_request_decided',
+    'initiative_pending',
+    'record_quarantined',
+    'publish_health'
+  ));
+
+alter table content.review_notifications
+  drop constraint if exists content_review_notification_shape_check;
+alter table content.review_notifications
+  add constraint content_review_notification_shape_check
+  check (
+    (kind in ('update_request_pending', 'update_request_decided') and request_id is not null)
+    or
+    (kind = 'initiative_pending' and request_id is null and initiative_slug <> '')
+    or
+    (kind = 'record_quarantined' and request_id is null and record_collection <> '' and record_slug <> '')
+    or
+    (
+      kind = 'publish_health'
+      and request_id is null
+      and event_key <> ''
+      and publish_health_kind in ('stale', 'build_failed')
+      and publish_health_status in ('active', 'recovered')
+      and jsonb_typeof(publish_health_details) = 'object'
+    )
+  );
+
+create unique index if not exists content_review_notification_event_key_idx
+  on content.review_notifications (event_key)
+  where event_key <> '';

--- a/packages/agent/src/content-operations.ts
+++ b/packages/agent/src/content-operations.ts
@@ -5,6 +5,7 @@
 // triggers enqueue and the agent observes/delivers. Secrets (GitHub dispatch
 // token, Resend key) stay on the agent; the CMS never holds them.
 
+import { assertPublicWebsiteBuildMetadata } from '@greenpill-network/shared/public-content';
 import { createDatabaseClient } from './db.js';
 
 type SqlLike = any;
@@ -19,6 +20,8 @@ export const CONTENT_REVIEW_NOTIFICATION_RETRY_MINUTES = Object.freeze([5, 30, 1
 export const CONTENT_DISPATCH_EVENT_TYPE = 'operational-content-updated';
 export const CONTENT_DISPATCH_DEFAULT_REPO = 'greenpill-dev-guild/network';
 export const CONTENT_DISPATCH_MIN_INTERVAL_MS = 5 * 60 * 1000;
+export const CONTENT_PUBLISH_HEALTH_DEFAULT_WORKFLOW = 'github-pages.yml';
+export const CONTENT_PUBLISH_HEALTH_DEFAULT_BRANCH = 'main';
 
 const cleanString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
@@ -34,6 +37,15 @@ function parseRecipients(value: unknown): string[] {
       .map((entry) => entry.toLowerCase())
       .filter((entry) => entry.length <= 320 && EMAIL_PATTERN.test(entry))
   )];
+}
+
+function parseHttpUrl(value: unknown): string {
+  try {
+    const url = new URL(cleanString(value));
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !url.username && !url.password ? url.href : '';
+  } catch {
+    return '';
+  }
 }
 
 function buildDirectusUrl(baseUrl: string, path: string): string {
@@ -58,6 +70,14 @@ export function getContentOperationsConfig(env: Record<string, string | undefine
     dispatchMinIntervalMs: Number.parseInt(env.CONTENT_DISPATCH_MIN_INTERVAL_MS ?? '', 10) > 0
       ? Number.parseInt(env.CONTENT_DISPATCH_MIN_INTERVAL_MS ?? '', 10)
       : CONTENT_DISPATCH_MIN_INTERVAL_MS,
+    publishHealthEnabled: cleanString(env.CONTENT_PUBLISH_HEALTH_ENABLED).toLowerCase() === 'true',
+    publishHealthMetadataUrl: parseHttpUrl(env.CONTENT_PUBLISH_HEALTH_METADATA_URL),
+    publishHealthStaleThresholdMs:
+      Number.parseInt(env.CONTENT_PUBLISH_HEALTH_STALE_THRESHOLD_MS ?? '', 10) > 0
+        ? Number.parseInt(env.CONTENT_PUBLISH_HEALTH_STALE_THRESHOLD_MS ?? '', 10)
+        : 0,
+    publishHealthWorkflow: cleanString(env.CONTENT_PUBLISH_HEALTH_WORKFLOW) || CONTENT_PUBLISH_HEALTH_DEFAULT_WORKFLOW,
+    publishHealthBranch: cleanString(env.CONTENT_PUBLISH_HEALTH_BRANCH) || CONTENT_PUBLISH_HEALTH_DEFAULT_BRANCH,
     resendApiKey: cleanString(env.RESEND_API_KEY),
     emailFrom: cleanString(env.CONTENT_REVIEW_EMAIL_FROM) || cleanString(env.MAP_NODE_EMAIL_FROM),
     emailReplyTo: cleanString(env.CONTENT_REVIEW_EMAIL_REPLY_TO) || cleanString(env.MAP_NODE_EMAIL_REPLY_TO),
@@ -167,13 +187,323 @@ export async function maybeDispatchContentRebuild(
   return { status: 'dispatched', watermark };
 }
 
+// --- Deployed publish health -------------------------------------------------
+
+export interface ContentPublishHealthObservation {
+  contentWatermark: string;
+  deployedBuildAt: string;
+  deployedSnapshotGeneratedAt: string;
+  pagesRunId: string;
+  pagesRunUrl: string;
+  pagesConclusion: string;
+  pagesCompletedAt: string;
+  checkedAt: string;
+  staleThresholdMs: number;
+}
+
+export interface ContentPublishHealthState {
+  staleAlertActive: boolean;
+  buildFailedAlertActive: boolean;
+  staleRecoveredAt: string;
+  buildFailedRecoveredAt: string;
+}
+
+export interface ContentPublishHealthTransition {
+  kind: 'stale' | 'build_failed';
+  status: 'active' | 'recovered';
+}
+
+export interface ContentPublishHealthEvaluation {
+  status: 'healthy' | 'stale' | 'build_failed' | 'stale_and_build_failed';
+  transitions: ContentPublishHealthTransition[];
+  nextState: ContentPublishHealthState;
+}
+
+const toIsoOrEmpty = (value: unknown): string => {
+  const cleaned = cleanString(value);
+  const date = value instanceof Date ? value : new Date(cleaned);
+  return (value instanceof Date || cleaned) && !Number.isNaN(date.valueOf()) ? date.toISOString() : '';
+};
+
+const toBoolean = (value: unknown): boolean => value === true || value === 'true';
+
+export function evaluateContentPublishHealth(
+  previous: ContentPublishHealthState,
+  observation: ContentPublishHealthObservation
+): ContentPublishHealthEvaluation {
+  const contentWatermarkMs = new Date(observation.contentWatermark).valueOf();
+  const deployedSnapshotMs = new Date(observation.deployedSnapshotGeneratedAt).valueOf();
+  if (
+    Number.isNaN(contentWatermarkMs) ||
+    Number.isNaN(deployedSnapshotMs) ||
+    !Number.isFinite(observation.staleThresholdMs) ||
+    observation.staleThresholdMs <= 0
+  ) {
+    throw new Error('invalid_publish_health_observation');
+  }
+
+  const stale = contentWatermarkMs - deployedSnapshotMs > observation.staleThresholdMs;
+  const buildFailed = cleanString(observation.pagesConclusion).toLowerCase() !== 'success';
+  const transitions: ContentPublishHealthTransition[] = [];
+
+  if (stale !== previous.staleAlertActive) {
+    transitions.push({ kind: 'stale', status: stale ? 'active' : 'recovered' });
+  }
+  if (buildFailed !== previous.buildFailedAlertActive) {
+    transitions.push({
+      kind: 'build_failed',
+      status: buildFailed ? 'active' : 'recovered',
+    });
+  }
+
+  return {
+    status: stale ? (buildFailed ? 'stale_and_build_failed' : 'stale') : buildFailed ? 'build_failed' : 'healthy',
+    transitions,
+    nextState: {
+      staleAlertActive: stale,
+      buildFailedAlertActive: buildFailed,
+      staleRecoveredAt: previous.staleAlertActive && !stale ? observation.checkedAt : previous.staleRecoveredAt,
+      buildFailedRecoveredAt:
+        previous.buildFailedAlertActive && !buildFailed ? observation.checkedAt : previous.buildFailedRecoveredAt,
+    },
+  };
+}
+
+export async function computeContentUpdatedAtWatermark(sql: SqlLike): Promise<string> {
+  const [row] = await sql`
+    select greatest(
+      coalesce((select max(updated_at) from content.themes), '-infinity'::timestamptz),
+      coalesce((select max(updated_at) from content.people), '-infinity'::timestamptz),
+      coalesce((select max(updated_at) from content.chapters), '-infinity'::timestamptz),
+      coalesce((select max(updated_at) from content.chapter_initiatives), '-infinity'::timestamptz),
+      coalesce((select max(updated_at) from content.guilds), '-infinity'::timestamptz),
+      coalesce((select max(updated_at) from content.projects), '-infinity'::timestamptz)
+    )::text as "contentWatermark"
+  `;
+  return toIsoOrEmpty(row?.contentWatermark);
+}
+
+function buildPagesWorkflowRunsUrl(repo: string, workflow: string, branch: string): string {
+  const [owner, name, ...extra] = cleanString(repo).split('/');
+  if (!owner || !name || extra.length > 0 || !cleanString(branch)) return '';
+  return (
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}` +
+    `/actions/workflows/${encodeURIComponent(workflow)}/runs` +
+    `?branch=${encodeURIComponent(branch)}&status=completed&per_page=1`
+  );
+}
+
+export async function fetchContentPublishHealthObservation(
+  sql: SqlLike,
+  {
+    env = process.env,
+    fetchImpl = globalThis.fetch,
+    now = new Date(),
+  }: {
+    env?: Record<string, string | undefined>;
+    fetchImpl?: FetchLike;
+    now?: Date | string;
+  } = {}
+): Promise<ContentPublishHealthObservation> {
+  const config = getContentOperationsConfig(env);
+  const workflowRunsUrl = buildPagesWorkflowRunsUrl(
+    config.dispatchRepo,
+    config.publishHealthWorkflow,
+    config.publishHealthBranch
+  );
+  if (
+    !config.publishHealthMetadataUrl ||
+    !config.publishHealthStaleThresholdMs ||
+    !config.dispatchToken ||
+    !workflowRunsUrl ||
+    typeof fetchImpl !== 'function'
+  ) {
+    throw new Error('publish_health_not_configured');
+  }
+
+  const [contentWatermark, metadataResponse, workflowResponse] = await Promise.all([
+    computeContentUpdatedAtWatermark(sql),
+    fetchImpl(config.publishHealthMetadataUrl, {
+      headers: { accept: 'application/json' },
+    }),
+    fetchImpl(workflowRunsUrl, {
+      headers: {
+        authorization: `Bearer ${config.dispatchToken}`,
+        accept: 'application/vnd.github+json',
+        'user-agent': 'greenpill-network-agent',
+      },
+    }),
+  ]);
+
+  if (!contentWatermark) throw new Error('publish_health_content_watermark_unavailable');
+  if (!metadataResponse.ok) throw new Error(`publish_health_metadata_http_${metadataResponse.status}`);
+  if (!workflowResponse.ok) throw new Error(`publish_health_workflow_http_${workflowResponse.status}`);
+
+  const metadata = assertPublicWebsiteBuildMetadata(await metadataResponse.json());
+  const workflowPayload = (await workflowResponse.json()) as {
+    workflow_runs?: unknown[];
+  };
+  const run = Array.isArray(workflowPayload?.workflow_runs)
+    ? (workflowPayload.workflow_runs[0] as Record<string, unknown> | undefined)
+    : undefined;
+  const pagesRunId = cleanString(run?.id === undefined || run?.id === null ? '' : String(run.id));
+  const pagesConclusion = cleanString(run?.conclusion).toLowerCase();
+  const pagesCompletedAt = toIsoOrEmpty(run?.updated_at);
+  if (!run || !pagesRunId || !pagesConclusion || !pagesCompletedAt) {
+    throw new Error('publish_health_workflow_run_unavailable');
+  }
+
+  return {
+    contentWatermark,
+    deployedBuildAt: metadata.builtAt,
+    deployedSnapshotGeneratedAt: metadata.operationalSnapshot.generatedAt,
+    pagesRunId,
+    pagesRunUrl: parseHttpUrl(run.html_url),
+    pagesConclusion,
+    pagesCompletedAt,
+    checkedAt: toIsoOrEmpty(now) || new Date().toISOString(),
+    staleThresholdMs: config.publishHealthStaleThresholdMs,
+  };
+}
+
+function publishHealthEventKey(
+  transition: ContentPublishHealthTransition,
+  observation: ContentPublishHealthObservation
+): string {
+  const marker =
+    transition.kind === 'build_failed'
+      ? observation.pagesRunId
+      : `${observation.contentWatermark}:${observation.deployedSnapshotGeneratedAt}`;
+  return `publish-health:${transition.kind}:${transition.status}:${marker}`;
+}
+
+export async function persistContentPublishHealthObservation(
+  sql: SqlLike,
+  observation: ContentPublishHealthObservation
+): Promise<ContentPublishHealthEvaluation> {
+  return sql.begin(async (tx: SqlLike) => {
+    const [row] = await tx`
+      select
+        stale_alert_active as "staleAlertActive",
+        build_failed_alert_active as "buildFailedAlertActive",
+        stale_recovered_at::text as "staleRecoveredAt",
+        build_failed_recovered_at::text as "buildFailedRecoveredAt"
+      from content.publish_health
+      where id = 'website'
+      for update
+    `;
+    if (!row) throw new Error('publish_health_state_unavailable');
+
+    const evaluation = evaluateContentPublishHealth(
+      {
+        staleAlertActive: toBoolean(row.staleAlertActive),
+        buildFailedAlertActive: toBoolean(row.buildFailedAlertActive),
+        staleRecoveredAt: toIsoOrEmpty(row.staleRecoveredAt),
+        buildFailedRecoveredAt: toIsoOrEmpty(row.buildFailedRecoveredAt),
+      },
+      observation
+    );
+
+    const details = {
+      contentWatermark: observation.contentWatermark,
+      deployedBuildAt: observation.deployedBuildAt,
+      deployedSnapshotGeneratedAt: observation.deployedSnapshotGeneratedAt,
+      pagesRunId: observation.pagesRunId,
+      pagesRunUrl: observation.pagesRunUrl,
+      pagesConclusion: observation.pagesConclusion,
+      pagesCompletedAt: observation.pagesCompletedAt,
+      checkedAt: observation.checkedAt,
+      staleThresholdMs: observation.staleThresholdMs,
+    };
+
+    for (const transition of evaluation.transitions) {
+      await tx`
+        insert into content.review_notifications (
+          kind,
+          event_key,
+          publish_health_kind,
+          publish_health_status,
+          publish_health_details
+        ) values (
+          'publish_health',
+          ${publishHealthEventKey(transition, observation)},
+          ${transition.kind},
+          ${transition.status},
+          ${tx.json(details)}
+        )
+        on conflict do nothing
+      `;
+    }
+
+    await tx`
+      update content.publish_health
+      set
+        content_watermark = ${observation.contentWatermark}::timestamptz,
+        deployed_build_at = ${observation.deployedBuildAt}::timestamptz,
+        deployed_snapshot_generated_at = ${observation.deployedSnapshotGeneratedAt}::timestamptz,
+        latest_pages_run_id = ${observation.pagesRunId},
+        latest_pages_run_url = ${observation.pagesRunUrl},
+        latest_pages_conclusion = ${observation.pagesConclusion},
+        latest_pages_completed_at = ${observation.pagesCompletedAt}::timestamptz,
+        stale_threshold_ms = ${observation.staleThresholdMs},
+        checked_at = ${observation.checkedAt}::timestamptz,
+        stale_alert_active = ${evaluation.nextState.staleAlertActive},
+        build_failed_alert_active = ${evaluation.nextState.buildFailedAlertActive},
+        stale_recovered_at = ${evaluation.nextState.staleRecoveredAt || null}::timestamptz,
+        build_failed_recovered_at = ${evaluation.nextState.buildFailedRecoveredAt || null}::timestamptz
+      where id = 'website'
+    `;
+
+    return evaluation;
+  });
+}
+
+export async function checkContentPublishHealth(
+  sql: SqlLike,
+  {
+    env = process.env,
+    fetchImpl = globalThis.fetch,
+    now = new Date(),
+  }: {
+    env?: Record<string, string | undefined>;
+    fetchImpl?: FetchLike;
+    now?: Date | string;
+  } = {}
+): Promise<{
+  status: 'disabled' | 'checked' | 'check_failed';
+  health?: ContentPublishHealthEvaluation['status'];
+}> {
+  const config = getContentOperationsConfig(env);
+  if (!config.publishHealthEnabled) return { status: 'disabled' };
+
+  try {
+    const observation = await fetchContentPublishHealthObservation(sql, {
+      env,
+      fetchImpl,
+      now,
+    });
+    const evaluation = await persistContentPublishHealthObservation(sql, observation);
+    console.log('content_publish_health_checked', {
+      health: evaluation.status,
+      transitions: evaluation.transitions.length,
+    });
+    return { status: 'checked', health: evaluation.status };
+  } catch (error) {
+    console.warn('content_publish_health_check_failed', {
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return { status: 'check_failed' };
+  }
+}
+
 // --- Content-review notifications -------------------------------------------
 
 type ReviewNotificationKind =
   | 'update_request_pending'
   | 'update_request_decided'
   | 'initiative_pending'
-  | 'record_quarantined';
+  | 'record_quarantined'
+  | 'publish_health';
 
 interface ReviewNotificationRow {
   id: string;
@@ -190,6 +520,9 @@ interface ReviewNotificationRow {
   reviewerNotes?: string;
   creatorEmail?: string;
   initiativeTitle?: string;
+  publishHealthKind?: ContentPublishHealthTransition['kind'];
+  publishHealthStatus?: ContentPublishHealthTransition['status'];
+  publishHealthDetails?: Partial<ContentPublishHealthObservation>;
 }
 
 export interface QueuedContentReviewDeliveryResult {
@@ -254,6 +587,25 @@ function quarantinedRecordEmailText(row: ReviewNotificationRow, recordUrl: strin
     'returns on the next snapshot automatically.',
     '',
     `Open it in Directus: ${recordUrl}`,
+  ].join('\n');
+}
+
+function publishHealthEmailText(row: ReviewNotificationRow): string {
+  const details = row.publishHealthDetails ?? {};
+  const recovered = row.publishHealthStatus === 'recovered';
+  const heading =
+    row.publishHealthKind === 'stale'
+      ? `Greenpill website publish freshness ${recovered ? 'RECOVERED' : 'is STALE'}.`
+      : `Greenpill GitHub Pages delivery ${recovered ? 'RECOVERED' : 'FAILED'}.`;
+  return [
+    heading,
+    '',
+    `Content watermark: ${toSafeEmailText(details.contentWatermark)}`,
+    `Deployed build: ${toSafeEmailText(details.deployedBuildAt)}`,
+    `Deployed snapshot: ${toSafeEmailText(details.deployedSnapshotGeneratedAt)}`,
+    `Pages conclusion: ${toSafeEmailText(details.pagesConclusion)}`,
+    `Checked at: ${toSafeEmailText(details.checkedAt)}`,
+    ...(details.pagesRunUrl ? ['', `Open the Pages run: ${toSafeEmailText(details.pagesRunUrl)}`] : []),
   ].join('\n');
 }
 
@@ -386,6 +738,21 @@ async function sendReviewEmail({
     to = config.reviewRecipients;
     subject = 'Greenpill public snapshot quarantined a record';
     text = quarantinedRecordEmailText(row, url);
+  } else if (row.kind === 'publish_health') {
+    if (!config.reviewRecipients.length) {
+      return {
+        status: 'send_failed',
+        error: 'no_review_recipients_configured',
+        providerMessageId: '',
+      };
+    }
+    to = config.reviewRecipients;
+    const recovered = row.publishHealthStatus === 'recovered';
+    subject =
+      row.publishHealthKind === 'stale'
+        ? `Greenpill website freshness ${recovered ? 'recovered' : 'alert'}`
+        : `Greenpill Pages delivery ${recovered ? 'recovered' : 'failed'}`;
+    text = publishHealthEmailText(row);
   } else {
     const url = row.requestId ? config.requestUrl(row.requestId) : '';
     if (!url) return { status: 'send_failed', error: 'directus_url_not_configured', providerMessageId: '' };
@@ -455,6 +822,9 @@ export async function deliverQueuedContentReviewNotifications(
       notification.record_slug as "recordSlug",
       notification.quarantine_reason as "quarantineReason",
       notification.request_status as "requestStatus",
+      notification.publish_health_kind as "publishHealthKind",
+      notification.publish_health_status as "publishHealthStatus",
+      notification.publish_health_details as "publishHealthDetails",
       request.title as "requestTitle",
       request.summary as "requestSummary",
       request.reviewer_notes as "reviewerNotes",
@@ -575,6 +945,9 @@ export function createContentOperationsRepository({
   return {
     maybeDispatchContentRebuild() {
       return withSql(createSql, (sql) => maybeDispatchContentRebuild(sql, dispatchState, { env, fetchImpl }));
+    },
+    checkPublishHealth() {
+      return withSql(createSql, (sql) => checkContentPublishHealth(sql, { env, fetchImpl }));
     },
     deliverQueuedReviewNotifications(options?: { limit?: number }) {
       return withSql(createSql, (sql) => deliverQueuedContentReviewNotifications(sql, {

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -131,15 +131,17 @@ export function startContentOperationsSweep({
   env?: Record<string, string | undefined>;
   repository?: {
     maybeDispatchContentRebuild?: () => Promise<unknown>;
+    checkPublishHealth?: () => Promise<unknown>;
     deliverQueuedReviewNotifications?: (options?: { limit?: number }) => Promise<unknown>;
     expireLiveOnboardingIfDue?: () => Promise<unknown>;
   };
 } = {}): (() => void) | null {
   if (!env.DATABASE_URL || env.CONTENT_OPERATIONS_SWEEP_ENABLED === 'false') return null;
   const dispatch = repository.maybeDispatchContentRebuild?.bind(repository);
+  const checkPublishHealth = repository.checkPublishHealth?.bind(repository);
   const deliver = repository.deliverQueuedReviewNotifications?.bind(repository);
   const expire = repository.expireLiveOnboardingIfDue?.bind(repository);
-  if (!dispatch && !deliver && !expire) return null;
+  if (!dispatch && !checkPublishHealth && !deliver && !expire) return null;
 
   const intervalMs = parsePositiveInteger(env.CONTENT_OPERATIONS_SWEEP_INTERVAL_MS, 60 * 1000);
 
@@ -150,6 +152,7 @@ export function startContentOperationsSweep({
     try {
       if (expire) await expire();
       if (dispatch) await dispatch();
+      if (checkPublishHealth) await checkPublishHealth();
       if (deliver) await deliver({ limit: 20 });
     } catch (error) {
       console.warn('content_operations_sweep_failed', {

--- a/packages/shared/src/public-content.ts
+++ b/packages/shared/src/public-content.ts
@@ -50,7 +50,17 @@ export interface PublicOperationalContentSnapshot {
   impactSourceBindings: PublicOperationalImpactSourcePayload;
 }
 
+export interface PublicWebsiteBuildMetadata {
+  version: 1;
+  builtAt: string;
+  operationalSnapshot: {
+    generatedAt: string;
+  };
+}
+
 export const PUBLIC_OPERATIONAL_CONTENT_VERSION = 1;
+export const PUBLIC_WEBSITE_BUILD_METADATA_VERSION = 1;
+export const PUBLIC_WEBSITE_BUILD_METADATA_ROUTE = '/build-metadata.json';
 
 export const PUBLIC_OPERATIONAL_CONTENT_COLLECTIONS: readonly PublicOperationalContentCollection[] = Object.freeze([
   'themes',
@@ -107,6 +117,14 @@ const toIso = (value: Date | string | null | undefined): string => {
   if (!value) return new Date().toISOString();
   const date = value instanceof Date ? value : new Date(value);
   return Number.isNaN(date.valueOf()) ? new Date().toISOString() : date.toISOString();
+};
+
+const requireIso = (value: unknown, field: string): string => {
+  const date = value instanceof Date ? value : new Date(cleanString(value));
+  if (Number.isNaN(date.valueOf())) {
+    throw new Error(`Public website build metadata has invalid ${field}`);
+  }
+  return date.toISOString();
 };
 
 const asArray = (value: unknown): any[] => (Array.isArray(value) ? value : []);
@@ -481,4 +499,48 @@ export function assertPublicOperationalContentSnapshot<T>(payload: T): T {
   }
 
   return payload;
+}
+
+export function toPublicWebsiteBuildMetadata({
+  builtAt = new Date(),
+  operationalSnapshotGeneratedAt,
+}: {
+  builtAt?: Date | string;
+  operationalSnapshotGeneratedAt: Date | string;
+}): PublicWebsiteBuildMetadata {
+  return {
+    version: PUBLIC_WEBSITE_BUILD_METADATA_VERSION,
+    builtAt: requireIso(builtAt, 'builtAt'),
+    operationalSnapshot: {
+      generatedAt: requireIso(operationalSnapshotGeneratedAt, 'operationalSnapshot.generatedAt'),
+    },
+  };
+}
+
+export function assertPublicWebsiteBuildMetadata(payload: unknown): PublicWebsiteBuildMetadata {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Public website build metadata must be an object');
+  }
+  if (containsPrivateOperationalContentField(payload)) {
+    throw new Error('Public website build metadata contains private fields');
+  }
+
+  const record = payload as UnknownRecord;
+  const rootKeys = Object.keys(record).sort();
+  if (
+    record.version !== PUBLIC_WEBSITE_BUILD_METADATA_VERSION ||
+    rootKeys.join(',') !== 'builtAt,operationalSnapshot,version'
+  ) {
+    throw new Error('Public website build metadata has an invalid shape');
+  }
+
+  const operationalSnapshot = normalizeObject(record.operationalSnapshot);
+  if (Object.keys(operationalSnapshot).join(',') !== 'generatedAt') {
+    throw new Error('Public website build metadata has an invalid operational snapshot shape');
+  }
+
+  return toPublicWebsiteBuildMetadata({
+    builtAt: requireIso(record.builtAt, 'builtAt'),
+    operationalSnapshotGeneratedAt: requireIso(operationalSnapshot.generatedAt, 'operationalSnapshot.generatedAt'),
+  });
 }

--- a/packages/website/src/lib/build-metadata.ts
+++ b/packages/website/src/lib/build-metadata.ts
@@ -1,0 +1,15 @@
+import {
+  toPublicWebsiteBuildMetadata,
+  type PublicWebsiteBuildMetadata,
+} from '@greenpill-network/shared/public-content';
+import { getOperationalContentSnapshot } from './operational-content.js';
+
+export async function getWebsiteBuildMetadata(
+  builtAt: Date | string = new Date()
+): Promise<PublicWebsiteBuildMetadata> {
+  const snapshot = await getOperationalContentSnapshot();
+  return toPublicWebsiteBuildMetadata({
+    builtAt,
+    operationalSnapshotGeneratedAt: snapshot.generatedAt,
+  });
+}

--- a/packages/website/src/pages/build-metadata.json.ts
+++ b/packages/website/src/pages/build-metadata.json.ts
@@ -1,0 +1,12 @@
+import { getWebsiteBuildMetadata } from '../lib/build-metadata';
+
+export const prerender = true;
+
+export async function GET() {
+  const metadata = await getWebsiteBuildMetadata();
+  return new Response(`${JSON.stringify(metadata, null, 2)}\n`, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+  });
+}

--- a/scripts/agent-contract.test.ts
+++ b/scripts/agent-contract.test.ts
@@ -8,6 +8,10 @@ import {
   createAgentApp,
 } from '@greenpill-network/agent/app';
 import {
+  deliverQueuedContentReviewNotifications,
+  evaluateContentPublishHealth,
+  fetchContentPublishHealthObservation,
+  persistContentPublishHealthObservation,
   RESEND_WEBHOOK_ROUTE,
   recordResendWebhookEvent,
   signResendWebhookPayload,
@@ -672,8 +676,250 @@ test('agent server starts a durable edit-link delivery sweep without logging pri
   assert.match(source, /startMapLocationCleanupSweep/);
   assert.match(source, /MAP_LOCATION_CLEANUP_SWEEP_INTERVAL_MS/);
   assert.match(source, /cleanupExpired/);
+  assert.match(source, /checkPublishHealth/);
   assert.match(source, /errorName/);
   assert.doesNotMatch(source, /console\.warn\([^;]*(email|token|normalized_email|request_ip)/s);
+});
+
+test('publish-health transitions cover healthy, stale, build-failed, repeated, and recovered sweeps', () => {
+  const inactive = {
+    staleAlertActive: false,
+    buildFailedAlertActive: false,
+    staleRecoveredAt: '',
+    buildFailedRecoveredAt: '',
+  };
+  const baseObservation = {
+    contentWatermark: '2026-08-11T12:10:00.000Z',
+    deployedBuildAt: '2026-08-11T12:05:00.000Z',
+    deployedSnapshotGeneratedAt: '2026-08-11T12:00:00.000Z',
+    pagesRunId: '101',
+    pagesRunUrl: 'https://github.com/greenpill-dev-guild/network/actions/runs/101',
+    pagesConclusion: 'success',
+    pagesCompletedAt: '2026-08-11T12:06:00.000Z',
+    checkedAt: '2026-08-11T12:11:00.000Z',
+    staleThresholdMs: 15 * 60 * 1000,
+  };
+
+  const healthy = evaluateContentPublishHealth(inactive, baseObservation);
+  assert.equal(healthy.status, 'healthy');
+  assert.deepEqual(healthy.transitions, []);
+
+  const stale = evaluateContentPublishHealth(inactive, {
+    ...baseObservation,
+    contentWatermark: '2026-08-11T12:20:00.001Z',
+  });
+  assert.equal(stale.status, 'stale');
+  assert.deepEqual(stale.transitions, [{ kind: 'stale', status: 'active' }]);
+
+  const buildFailed = evaluateContentPublishHealth(inactive, {
+    ...baseObservation,
+    pagesRunId: '102',
+    pagesConclusion: 'failure',
+  });
+  assert.equal(buildFailed.status, 'build_failed');
+  assert.deepEqual(buildFailed.transitions, [{ kind: 'build_failed', status: 'active' }]);
+
+  const repeated = evaluateContentPublishHealth(buildFailed.nextState, {
+    ...baseObservation,
+    pagesRunId: '102',
+    pagesConclusion: 'failure',
+  });
+  assert.equal(repeated.status, 'build_failed');
+  assert.deepEqual(repeated.transitions, []);
+
+  const recovered = evaluateContentPublishHealth(
+    {
+      staleAlertActive: true,
+      buildFailedAlertActive: true,
+      staleRecoveredAt: '',
+      buildFailedRecoveredAt: '',
+    },
+    {
+      ...baseObservation,
+      pagesRunId: '103',
+      checkedAt: '2026-08-11T12:30:00.000Z',
+    }
+  );
+  assert.equal(recovered.status, 'healthy');
+  assert.deepEqual(recovered.transitions, [
+    { kind: 'stale', status: 'recovered' },
+    { kind: 'build_failed', status: 'recovered' },
+  ]);
+  assert.equal(recovered.nextState.staleRecoveredAt, '2026-08-11T12:30:00.000Z');
+  assert.equal(recovered.nextState.buildFailedRecoveredAt, '2026-08-11T12:30:00.000Z');
+});
+
+test('publish-health polling compares the public build artifact with content and Pages state', async () => {
+  const calls = [];
+  const sql = async (strings) => {
+    const source = strings.join(' ');
+    if (source.includes('select greatest')) {
+      return [{ contentWatermark: '2026-08-11T12:20:00.000Z' }];
+    }
+    return [];
+  };
+
+  const observation = await fetchContentPublishHealthObservation(sql, {
+    env: {
+      CONTENT_DISPATCH_GITHUB_TOKEN: 'test-actions-read-token',
+      CONTENT_DISPATCH_GITHUB_REPO: 'greenpill-dev-guild/network',
+      CONTENT_PUBLISH_HEALTH_METADATA_URL: 'https://greenpill.network/build-metadata.json',
+      CONTENT_PUBLISH_HEALTH_STALE_THRESHOLD_MS: String(15 * 60 * 1000),
+    },
+    now: '2026-08-11T12:21:00.000Z',
+    fetchImpl: async (url, options) => {
+      calls.push({ url: String(url), options });
+      if (String(url).includes('build-metadata.json')) {
+        return Response.json({
+          version: 1,
+          builtAt: '2026-08-11T12:05:00.000Z',
+          operationalSnapshot: { generatedAt: '2026-08-11T12:00:00.000Z' },
+        });
+      }
+      return Response.json({
+        workflow_runs: [
+          {
+            id: 104,
+            conclusion: 'failure',
+            updated_at: '2026-08-11T12:06:00.000Z',
+            html_url: 'https://github.com/greenpill-dev-guild/network/actions/runs/104',
+          },
+        ],
+      });
+    },
+  });
+
+  assert.deepEqual(observation, {
+    contentWatermark: '2026-08-11T12:20:00.000Z',
+    deployedBuildAt: '2026-08-11T12:05:00.000Z',
+    deployedSnapshotGeneratedAt: '2026-08-11T12:00:00.000Z',
+    pagesRunId: '104',
+    pagesRunUrl: 'https://github.com/greenpill-dev-guild/network/actions/runs/104',
+    pagesConclusion: 'failure',
+    pagesCompletedAt: '2026-08-11T12:06:00.000Z',
+    checkedAt: '2026-08-11T12:21:00.000Z',
+    staleThresholdMs: 15 * 60 * 1000,
+  });
+  assert.equal(calls.length, 2);
+  assert.match(calls[1].url, /actions\/workflows\/github-pages\.yml\/runs/);
+  assert.equal(new URL(calls[1].url).searchParams.get('branch'), 'main');
+  assert.equal(calls[1].options.headers.authorization, 'Bearer test-actions-read-token');
+});
+
+test('publish-health persistence serializes state and deduplicates repeated alerts', async () => {
+  const notifications = [];
+  const state = {
+    staleAlertActive: false,
+    buildFailedAlertActive: false,
+    staleRecoveredAt: '',
+    buildFailedRecoveredAt: '',
+  };
+  const tx = async (strings, ...values) => {
+    const source = strings.join(' ');
+    if (source.includes('from content.publish_health')) return [{ ...state }];
+    if (source.includes('insert into content.review_notifications')) {
+      notifications.push({ eventKey: values[0], kind: values[1], status: values[2] });
+      return [];
+    }
+    if (source.includes('update content.publish_health')) {
+      state.staleAlertActive = values[9];
+      state.buildFailedAlertActive = values[10];
+      state.staleRecoveredAt = values[11] ?? '';
+      state.buildFailedRecoveredAt = values[12] ?? '';
+    }
+    return [];
+  };
+  tx.json = (value) => value;
+  const sql = async () => [];
+  sql.begin = async (callback) => callback(tx);
+
+  const staleObservation = {
+    contentWatermark: '2026-08-11T12:20:00.001Z',
+    deployedBuildAt: '2026-08-11T12:05:00.000Z',
+    deployedSnapshotGeneratedAt: '2026-08-11T12:00:00.000Z',
+    pagesRunId: '105',
+    pagesRunUrl: 'https://github.com/greenpill-dev-guild/network/actions/runs/105',
+    pagesConclusion: 'success',
+    pagesCompletedAt: '2026-08-11T12:06:00.000Z',
+    checkedAt: '2026-08-11T12:21:00.000Z',
+    staleThresholdMs: 15 * 60 * 1000,
+  };
+
+  await persistContentPublishHealthObservation(sql, staleObservation);
+  await persistContentPublishHealthObservation(sql, staleObservation);
+  assert.deepEqual(notifications, [{
+    eventKey: 'publish-health:stale:active:2026-08-11T12:20:00.001Z:2026-08-11T12:00:00.000Z',
+    kind: 'stale',
+    status: 'active',
+  }]);
+  assert.equal(state.staleAlertActive, true);
+
+  await persistContentPublishHealthObservation(sql, {
+    ...staleObservation,
+    contentWatermark: '2026-08-11T12:10:00.000Z',
+    deployedSnapshotGeneratedAt: '2026-08-11T12:30:00.000Z',
+    pagesRunId: '106',
+    checkedAt: '2026-08-11T12:31:00.000Z',
+  });
+  assert.equal(notifications.length, 2);
+  assert.deepEqual(notifications[1], {
+    eventKey: 'publish-health:stale:recovered:2026-08-11T12:10:00.000Z:2026-08-11T12:30:00.000Z',
+    kind: 'stale',
+    status: 'recovered',
+  });
+  assert.equal(state.staleAlertActive, false);
+  assert.equal(state.staleRecoveredAt, '2026-08-11T12:31:00.000Z');
+});
+
+test('publish-health alerts and recoveries deliver through the durable Resend queue', async () => {
+  const statements = [];
+  let resendRequest;
+  const sql = async (strings) => {
+    const source = strings.join(' ');
+    statements.push(source);
+    if (source.includes('from content.review_notifications notification')) {
+      return [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          kind: 'publish_health',
+          publishHealthKind: 'stale',
+          publishHealthStatus: 'active',
+          publishHealthDetails: {
+            contentWatermark: '2026-08-11T12:20:00.000Z',
+            deployedBuildAt: '2026-08-11T12:05:00.000Z',
+            deployedSnapshotGeneratedAt: '2026-08-11T12:00:00.000Z',
+            pagesConclusion: 'success',
+            checkedAt: '2026-08-11T12:21:00.000Z',
+          },
+        },
+      ];
+    }
+    if (source.includes('returning attempts')) return [{ attempts: 1 }];
+    return [];
+  };
+
+  const result = await deliverQueuedContentReviewNotifications(sql, {
+    env: {
+      RESEND_API_KEY: 'test-resend-key',
+      CONTENT_REVIEW_EMAIL_FROM: 'Greenpill <alerts@example.org>',
+      CONTENT_REVIEW_RECIPIENTS: 'operator@example.org',
+    },
+    fetchImpl: async (url, options) => {
+      resendRequest = { url: String(url), options };
+      return Response.json({ id: 'provider-message-1' });
+    },
+  });
+
+  assert.deepEqual(result, { queued: 1, delivered: 1, failed: 0, skipped: 0 });
+  assert.equal(resendRequest.options.headers['Idempotency-Key'], 'content-review-11111111-1111-4111-8111-111111111111');
+  const body = JSON.parse(resendRequest.options.body);
+  assert.deepEqual(body.to, ['operator@example.org']);
+  assert.equal(body.subject, 'Greenpill website freshness alert');
+  assert.match(body.text, /publish freshness is STALE/);
+  assert.equal(
+    statements.some((source) => source.includes("status = 'sent'")),
+    true
+  );
 });
 
 const RESEND_TEST_WEBHOOK_SECRET = `whsec_${Buffer.from('test-resend-webhook-secret').toString('base64')}`;

--- a/scripts/public-content-contract.test.ts
+++ b/scripts/public-content-contract.test.ts
@@ -5,9 +5,12 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   assertPublicOperationalContentSnapshot,
+  assertPublicWebsiteBuildMetadata,
   containsPrivateOperationalContentField,
   containsUnapprovedChapterMedia,
+  PUBLIC_WEBSITE_BUILD_METADATA_ROUTE,
   toPublicOperationalContentSnapshot,
+  toPublicWebsiteBuildMetadata,
 } from '@greenpill-network/shared/public-content';
 import {
   buildDirectusOperationalPermissionPlan,
@@ -42,6 +45,7 @@ const storiesIndexPagePath = join(rootDir, 'packages/website/src/pages/stories/i
 const chapterPagePath = join(rootDir, 'packages/website/src/pages/chapters/[slug].astro');
 const chapterInitiativesMigrationPath = join(rootDir, 'packages/agent/migrations/010_chapter_initiatives_operational_content.sql');
 const chapterImageUploadsMigrationPath = join(rootDir, 'packages/agent/migrations/022_chapter_image_uploads.sql');
+const contentPublishHealthMigrationPath = join(rootDir, 'packages/agent/migrations/028_content_publish_health.sql');
 const activeChapterEnrichmentSlugs = [
   'brasil',
   'c-te-d-ivoire',
@@ -209,6 +213,46 @@ test('operational content snapshot is public-safe and derived from approved oper
   assert.equal(snapshot.locations.length > 0, true);
   assert.equal(Array.isArray(snapshot.impactSourceBindings.chapters), true);
   assert.equal(containsPrivateOperationalContentField(snapshot), false);
+});
+
+test('website build metadata exposes only static public snapshot freshness timestamps', async () => {
+  const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+  const metadata = toPublicWebsiteBuildMetadata({
+    builtAt: '2026-08-11T18:30:00.000Z',
+    operationalSnapshotGeneratedAt: snapshot.generatedAt,
+  });
+
+  assert.equal(PUBLIC_WEBSITE_BUILD_METADATA_ROUTE, '/build-metadata.json');
+  assert.deepEqual(metadata, {
+    version: 1,
+    builtAt: '2026-08-11T18:30:00.000Z',
+    operationalSnapshot: {
+      generatedAt: snapshot.generatedAt,
+    },
+  });
+  assert.deepEqual(assertPublicWebsiteBuildMetadata(metadata), metadata);
+  assert.equal(containsPrivateOperationalContentField(metadata), false);
+  assert.throws(
+    () =>
+      assertPublicWebsiteBuildMetadata({
+        ...metadata,
+        stewardEmail: 'private@example.org',
+      }),
+    /private fields/
+  );
+});
+
+test('publish-health migration stores durable state and reuses the deduplicated review queue', async () => {
+  const migration = await readFile(contentPublishHealthMigrationPath, 'utf8');
+
+  assert.match(migration, /create table if not exists content\.publish_health/);
+  assert.match(migration, /deployed_build_at timestamptz/);
+  assert.match(migration, /deployed_snapshot_generated_at timestamptz/);
+  assert.match(migration, /stale_alert_active boolean/);
+  assert.match(migration, /build_failed_alert_active boolean/);
+  assert.match(migration, /publish_health_status in \('active', 'recovered'\)/);
+  assert.match(migration, /content_review_notification_event_key_idx/);
+  assert.doesNotMatch(migration, /email|ip_address|user_agent|steward_notes/);
 });
 
 test('Keystatic and Astro content configs expose editorial collections only', async () => {


### PR DESCRIPTION
## Summary
- add a static public website build-metadata artifact tied to the approved operational snapshot
- persist Directus publish-health state and queue durable stale, build-failed, and recovery notifications through the existing Resend delivery path
- reconcile the active Directus CMS plan while keeping PRD-809 and production activation outside this change

## Validation
- [x] shared and agent package TypeScript compile passes
- [x] agent contract suites pass: 82 tests
- [x] public content contract suite passes: 23 tests
- [x] plan contract suite passes: 7 tests
- [x] `bun --no-env-file scripts/plan-hub.ts validate` validates 10 plan hubs
- [x] Astro production build passes: 47 pages, including `/build-metadata.json`
- [ ] full root `bun run typecheck` remains blocked by four unchanged PRD-809 errors in `scripts/directus-studio-setup.ts` at lines 942, 1012, 1015, and 1334

## Release boundary
This draft does not apply migration 028, deploy Fly, change Fly secrets or token permissions, enable the watchdog, or perform a live alert test. Production activation remains a separate reviewed release step.

Closes PRD-808